### PR TITLE
Removing ONBUILD job for copying in a fluent.conf 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,6 @@ ENV PATH /home/fluent/.gem/ruby/2.2.0/bin:$PATH
 ENV GEM_PATH /home/fluent/.gem/ruby/2.2.0:$GEM_PATH
 
 COPY fluent.conf /fluentd/etc/
-ONBUILD COPY fluent.conf /fluentd/etc/
 ONBUILD COPY plugins /fluentd/plugins/
 
 ENV FLUENTD_OPT=""


### PR DESCRIPTION
Remove onbuild job for copying in fluent.conf.

The ENV var can overwrite the name of the config file, so there should be no need to force an onbuild to do it for you.

Also stops downstream implementors not using a file called fluent.conf.